### PR TITLE
Fix most features being broken on play.mccisland.com

### DIFF
--- a/src/main/kotlin/cc/pe3epwithyou/trident/state/MCCIState.kt
+++ b/src/main/kotlin/cc/pe3epwithyou/trident/state/MCCIState.kt
@@ -19,6 +19,6 @@ object MCCIState {
     fun isOnIsland(): Boolean {
         if (Config.Debug.bypassOnIsland) return true
         val server = Minecraft.getInstance().currentServer ?: return false
-        return server.ip.contains("mccisland.net", true)
+        return server.ip.contains("mccisland.net", true) || server.ip.contains("mccisland.com", true)
     }
 }


### PR DESCRIPTION
Almost every feature (excluding the questing and fishing modules) was broken if you connected to play.mccisland.com instead of mccisland.net.

I can't confirm that it is fixed now (that ip is dead for me), but I can confirm nothing is broken👍 