### PR TITLE
🐛 Fix compact infinibag display overflowing numbers greater than 10K (#71)

### DIFF
--- a/src/main/kotlin/cc/pe3epwithyou/trident/feature/EnhancedCompactInfinibag.kt
+++ b/src/main/kotlin/cc/pe3epwithyou/trident/feature/EnhancedCompactInfinibag.kt
@@ -36,9 +36,9 @@ object EnhancedCompactInfinibag {
         graphics.pose().pushMatrix()
 
         val pose = graphics.pose()
-        val factor = ((16f / width) * 0.9f).coerceAtMost(1f)
-        pose.scaleAround(factor, factor, slot.x.toFloat() + width, slot.y.toFloat() + 9, pose)
-        graphics.text(font, formatted, slot.x + 15 - width, slot.y + 9, 0xffffff.opaqueColor())
+        val factor = ((16f / width) * 0.9f).coerceAtMost(0.9f)
+        pose.scaleAround(factor, factor, slot.x.toFloat(), slot.y.toFloat() + (8 * (2 - factor)), pose)
+        graphics.text(font, formatted, slot.x + (16-((width * factor).toInt()))/2, slot.y + 9, 0xffffff.opaqueColor())
 
         graphics.pose().popMatrix()
     }


### PR DESCRIPTION
- For the Y-axis scaling, the offset formula subtracts the factor from 2 so its position stays centered along the background properly
- To fix the x-axis positioning, I just changed the text rendering line to add the half of the un-covered slot size (so where the text isn't), centering it (except for maybe a 1px difference here and there due to rounding)
logic isn't the best imo because matrices are definitely not something im good at, but I hope this helps 🙏 

<img width="397" height="293" alt="image" src="https://github.com/user-attachments/assets/f4bc73d1-90c6-4ba8-94b8-a08a57efadc1" />
